### PR TITLE
_loadData Fixes 

### DIFF
--- a/scripts/grid.js
+++ b/scripts/grid.js
@@ -1683,10 +1683,18 @@
                     url: data,
                     config: self.options.xhrconfig,
                     extract: function (xhr, xhrOpts) {
-                        if (xhr.status !== 200) {
-                            return self.options.ondataloaderror(xhr);
+                        var responseText = xhr.responseText;
+                        try {
+                            JSON.parse(responseText);
+                        } catch (e) {
+                            responseText = JSON.stringify(responseText);
                         }
-                        return xhr.responseText;
+
+                        if (xhr.status !== 200) {
+                            self.options.ondataloaderror(xhr);
+                        }
+
+                        return responseText;
                     }
                 })
                     .then(function _requestBuildtree(value) {


### PR DESCRIPTION
#### Purpose
- Removes the [`return`](https://github.com/CenterForOpenScience/treebeard/compare/develop...caseyrollins:feature/load-data-fixes?expand=1#diff-5e86a52991278e8e3d26c432a3aad1eeL1687) statement in case of a non-200 response. Mithril's extract method should still return response text, not an `ondataloaderror` call. 
- Adds error handling for a non-JSON response. 
- Resolves [5825](https://openscience.atlassian.net/browse/OSF-5825) (note: the `return` statement removal is what resolves this issue, the added error handling is just good to have)

h/t @samchrisinger for JSON parsing/stringify-ing help.