### PR TITLE
[Feature] OSF-6485 Make isSorted false for all columns

### DIFF
--- a/scripts/grid.js
+++ b/scripts/grid.js
@@ -1158,8 +1158,10 @@
                 sortType = element.attr('data-sortType');
             }
             self.select('.asc-btn, .desc-btn').addClass('tb-sort-inactive'); // turn all styles off
-            self.isSorted[col].asc = false;
-            self.isSorted[col].desc = false;
+            for(var column in self.isSorted) {
+                self.isSorted[column].asc = false;
+                self.isSorted[column].desc = false;
+            }
             if (!self.isSorted[col][type]) {
                 redo = function _redo(data) {
                     data.map(function _mapToggle(item) {


### PR DESCRIPTION
## Purpose
The sort function currently only makes false the asc/desc values of its own column and then sets the proper asc/desc value to TRUE. When a user has sorted on various columns, each column maintains the previous TRUE/FALSE values for asc/desc. This makes it impossible to use the status of each columns asc/desc to determine which column was last sorted. By instead making all column's asc/desc values FALSE, the only column with a TRUE value is known to be the last changed column, allowing for the previous sort method to be maintained without requiring a check of sort button icon classes or storing the last sort method call. 

## Changes
Sort function now toggles false all columns asc/desc values.

## Side Effects
None known.